### PR TITLE
Update minimum Ansible version to 1.6

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Install the Go Continuous Delivery tool.  Model even the most complex build and deploy workflow with ease."
   company: "ThoughtWorks, Inc."
   license: MIT
-  min_ansible_version: 1.5
+  min_ansible_version: 1.6
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
I went to use this module via ansible-galaxy and ran into difficulties because Ansible 1.6 is required for the ufw module, but a minimum version of 1.5 is specified. This is a fix to the galaxy_info to specify 1.6 as the minimum.

http://docs.ansible.com/ufw_module.html
