### PR TITLE
Fixed detection of latest gocd version under apt.

### DIFF
--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -68,16 +68,20 @@
   file: path=/etc/go state=directory owner={{ GOCD_USER }} group={{ GOCD_GROUP }}
 
 - name: determine latest version of Go available in yum repo
-  shell: "yum list go-server |grep go-server |awk '{print $2}'"
+  shell: yum list go-server |grep go-server |awk '{print $2}'
   register: tmp_go_version
   changed_when: false
   when: GOCD_GO_VERSION == 'latest' and ansible_pkg_mgr=='yum'
+  tags:
+    - skip_ansible_lint
 
 - name: determine latest version of Go available in apt repo
-  shell: "apt-cache show go-server |grep Version |awk '{print $2}' |head -1"
+  shell: apt-cache show go-server |grep Version |awk '{print $2}' |head -1
   register: tmp_go_version
   changed_when: false
   when: GOCD_GO_VERSION == 'latest' and ansible_pkg_mgr=='apt'
+  tags:
+    - skip_ansible_lint
 
 - name: Set GOCD_GO_VERSION to latest
   set_fact:

--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -67,11 +67,17 @@
   sudo: yes
   file: path=/etc/go state=directory owner={{ GOCD_USER }} group={{ GOCD_GROUP }}
 
-- name: determine latest version of Go available in repo
-  shell: "{{ ansible_pkg_mgr }} list go-server |grep go-server |awk '{print $2}'"
+- name: determine latest version of Go available in yum repo
+  shell: "yum list go-server |grep go-server |awk '{print $2}'"
   register: tmp_go_version
   changed_when: false
-  when: GOCD_GO_VERSION == 'latest'
+  when: GOCD_GO_VERSION == 'latest' and ansible_pkg_mgr=='yum'
+
+- name: determine latest version of Go available in apt repo
+  shell: "apt-cache show go-server |grep Version |awk '{print $2}' |head -1"
+  register: tmp_go_version
+  changed_when: false
+  when: GOCD_GO_VERSION == 'latest' and ansible_pkg_mgr=='apt'
 
 - name: Set GOCD_GO_VERSION to latest
   set_fact:
@@ -108,4 +114,3 @@
   sudo: yes
   apt: pkg=subversion state=present
   when: ansible_pkg_mgr=='apt' and GOCD_SCM_SVN
-


### PR DESCRIPTION
I found that this role no longer worked on debian systems since 089b658012bb3ca1abed5cac0544b30282d7ce65 (Ubuntu in my case) because it was trying to run the shell command `apt list go-server` and the command `apt` is not a valid one.

In this PR I've split it out into a yum-specific task and an apt-specific one (tweaked to get a correct latest version) following the way the rest of go-common.yml is done.