### PR TITLE
Make gocd debian repository configurable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
+GOCD_DEBIAN_REPOSITORY: http://dl.bintray.com/gocd/gocd-deb/
 GOCD_GO_VERSION: latest
 GOCD_JAVA_HOME: /usr/lib/jvm/java
 GOCD_AGENT_INSTANCES: "{{ ansible_processor_count * ansible_processor_cores }}"

--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -39,7 +39,7 @@
 
 - name: thoughtworks go apt repository
   sudo: yes
-  apt_repository: repo='deb http://dl.bintray.com/gocd/gocd-deb/ /' state=present
+  apt_repository: repo='deb {{GOCD_DEBIAN_REPOSITORY}} /' state=present
   when: ansible_pkg_mgr == 'apt'
 
 # Note: If the user or group exists, but under another ID, Ansible will try and change it.


### PR DESCRIPTION
In an intranet setup you often are not able to access the internet,
so let the debian be configurable.