### PR TITLE
Assertion always failing when setting GOCD_CONFIGURE_SMTP

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
+GOCD_DEBIAN_REPOSITORY: http://dl.bintray.com/gocd/gocd-deb/
 GOCD_GO_VERSION: latest
 GOCD_JAVA_HOME: /usr/lib/jvm/java
 GOCD_AGENT_INSTANCES: "{{ ansible_processor_count * ansible_processor_cores }}"

--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -39,7 +39,7 @@
 
 - name: thoughtworks go apt repository
   sudo: yes
-  apt_repository: repo='deb http://dl.bintray.com/gocd/gocd-deb/ /' state=present
+  apt_repository: repo='deb {{GOCD_DEBIAN_REPOSITORY}} /' state=present
   when: ansible_pkg_mgr == 'apt'
 
 # Note: If the user or group exists, but under another ID, Ansible will try and change it.

--- a/tasks/server-config.yml
+++ b/tasks/server-config.yml
@@ -35,7 +35,7 @@
   assert:
      that:
         - GOCD_SMTP_PASSWORD is defined or GOCD_SMTP_ENCRYPTED_PASSWORD is defined
-  when: GOCD_CONFIGURE_SMTP and GOCD_SMTP_USER
+  when: GOCD_CONFIGURE_SMTP is defined and GOCD_SMTP_USER is defined
 
 - name: Verify that minimum LDAP security configuration variables are defined
   assert:


### PR DESCRIPTION
The condition `GOCD_CONFIGURE_SMTP and GOCD_SMTP_USER` always seemed
to be true, once I defined GOCD_CONFIGURE_SMTP to be true *without* defining GOCD_SMTP_USER.