### PR TITLE
Replace tags with variable for gocd roles

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
+GOCD_DEBIAN_REPOSITORY: http://dl.bintray.com/gocd/gocd-deb/
 GOCD_GO_VERSION: latest
 GOCD_JAVA_HOME: /usr/lib/jvm/java
 GOCD_AGENT_INSTANCES: "{{ ansible_processor_count * ansible_processor_cores }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,9 @@ GOCD_USER: go
 GOCD_USERID: 5000
 GOCD_GROUP: go
 GOCD_GROUPID: 5000
-
+GOCD_ROLES:
+  - server
+  - agent
 # Agent auto-registration; this is insecure and you should override this value for real usage
 GOCD_AUTO_REGISTER_KEY: insecure_registration_key
 

--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -39,7 +39,7 @@
 
 - name: thoughtworks go apt repository
   sudo: yes
-  apt_repository: repo='deb http://dl.bintray.com/gocd/gocd-deb/ /' state=present
+  apt_repository: repo='deb {{GOCD_DEBIAN_REPOSITORY}} /' state=present
   when: ansible_pkg_mgr == 'apt'
 
 # Note: If the user or group exists, but under another ID, Ansible will try and change it.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
    # - include: coreos.yml
    #   when: ansible_lsb.id=='CoreOS'
-   - include: go-common.yml tags=server,agent
-   - include: go-server.yml tags=server
-   - include: go-agent.yml tags=agent
-   - include: server-config.yml tags=server
-     when: GOCD_CONFIGURE
+   - include: go-common.yml
+     when: "'server' in GOCD_ROLES or 'agent' in GOCD_ROLES"
+   - include: go-server.yml
+     when: "'server' in GOCD_ROLES"
+   - include: go-agent.yml
+     when: "'agent' in GOCD_ROLES"
+   - include: server-config.yml
+     when: "GOCD_CONFIGURE is defined and 'server' in GOCD_ROLES"

--- a/tasks/server-config.yml
+++ b/tasks/server-config.yml
@@ -35,7 +35,7 @@
   assert:
      that:
         - GOCD_SMTP_PASSWORD is defined or GOCD_SMTP_ENCRYPTED_PASSWORD is defined
-  when: GOCD_CONFIGURE_SMTP and GOCD_SMTP_USER
+  when: GOCD_CONFIGURE_SMTP is defined and GOCD_SMTP_USER is defined
 
 - name: Verify that minimum LDAP security configuration variables are defined
   assert:


### PR DESCRIPTION
As I understand the intentation of the tags, I thought that some parts should only be executed on a host used as server and some parts only be executed on hosts used as agents. While a multi-role approach would be nicer, at least this is an easier patch.