### PR TITLE
Insert additional environment in defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
+GOCD_DEBIAN_REPOSITORY: http://dl.bintray.com/gocd/gocd-deb/
 GOCD_GO_VERSION: latest
 GOCD_JAVA_HOME: /usr/lib/jvm/java
 GOCD_AGENT_INSTANCES: "{{ ansible_processor_count * ansible_processor_cores }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,9 @@ GOCD_USER: go
 GOCD_USERID: 5000
 GOCD_GROUP: go
 GOCD_GROUPID: 5000
-
+GOCD_ROLES:
+  - server
+  - agent
 # Agent auto-registration; this is insecure and you should override this value for real usage
 GOCD_AUTO_REGISTER_KEY: insecure_registration_key
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,10 @@ GOCD_ROLES:
 # Agent auto-registration; this is insecure and you should override this value for real usage
 GOCD_AUTO_REGISTER_KEY: insecure_registration_key
 
+# Use to insert additonal environment variables.
+GOCD_AGENT_ADDITIONAL_DEFAULTS:
+GOCD_SERVER_ADDITIONAL_DEFAULTS:
+
 # Basic SCM dependencies
 GOCD_SCM_GIT: false
 GOCD_SCM_MERCURIAL: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,7 @@
      - ensure go-server running
 
 - name: ensure go-server running
-  wait_for: port=8153 timeout=180 delay=10
+  wait_for: port={{ GOCD_SERVER_PORT }} timeout=180 delay=10
 
 - name: restart firewalld
   sudo: yes

--- a/tasks/go-common.yml
+++ b/tasks/go-common.yml
@@ -39,7 +39,7 @@
 
 - name: thoughtworks go apt repository
   sudo: yes
-  apt_repository: repo='deb http://dl.bintray.com/gocd/gocd-deb/ /' state=present
+  apt_repository: repo='deb {{GOCD_DEBIAN_REPOSITORY}} /' state=present
   when: ansible_pkg_mgr == 'apt'
 
 # Note: If the user or group exists, but under another ID, Ansible will try and change it.

--- a/tasks/go-server.yml
+++ b/tasks/go-server.yml
@@ -43,7 +43,7 @@
 
 - name: enable Go HTTP traffic through firewalld
   sudo: yes
-  firewalld: port=8153/tcp permanent=true state=enabled
+  firewalld: port={{ GOCD_SERVER_PORT }}/tcp permanent=true state=enabled
   when: firewalld|success and firewalld_svc.stdout=='running'
   notify:
     - restart firewalld
@@ -63,7 +63,7 @@
 
 - name: enable Go HTTP traffic through ufw
   sudo: yes
-  ufw: rule=allow port=8153 proto=tcp
+  ufw: rule=allow port={{ GOCD_SERVER_PORT }} proto=tcp
   when: ufw|success
 
 - name: enable Go HTTPS traffic through ufw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
    # - include: coreos.yml
    #   when: ansible_lsb.id=='CoreOS'
-   - include: go-common.yml tags=server,agent
-   - include: go-server.yml tags=server
-   - include: go-agent.yml tags=agent
-   - include: server-config.yml tags=server
-     when: GOCD_CONFIGURE
+   - include: go-common.yml
+     when: "'server' in GOCD_ROLES or 'agent' in GOCD_ROLES"
+   - include: go-server.yml
+     when: "'server' in GOCD_ROLES"
+   - include: go-agent.yml
+     when: "'agent' in GOCD_ROLES"
+   - include: server-config.yml
+     when: "GOCD_CONFIGURE is defined and 'server' in GOCD_ROLES"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,4 +8,4 @@
    - include: go-agent.yml
      when: "'agent' in GOCD_ROLES"
    - include: server-config.yml
-     when: "GOCD_CONFIGURE is defined and 'server' in GOCD_ROLES"
+     when: "GOCD_CONFIGURE and 'server' in GOCD_ROLES"

--- a/tasks/server-config.yml
+++ b/tasks/server-config.yml
@@ -35,7 +35,7 @@
   assert:
      that:
         - GOCD_SMTP_PASSWORD is defined or GOCD_SMTP_ENCRYPTED_PASSWORD is defined
-  when: GOCD_CONFIGURE_SMTP and GOCD_SMTP_USER
+  when: GOCD_CONFIGURE_SMTP is defined and GOCD_SMTP_USER is defined
 
 - name: Verify that minimum LDAP security configuration variables are defined
   assert:

--- a/tasks/server-config.yml
+++ b/tasks/server-config.yml
@@ -146,10 +146,10 @@
   when: tmp_go_passwd.stat.exists == False
 
 - name: Wait for Go to start
-  wait_for: port=8153 timeout=180
+  wait_for: port={{ GOCD_SERVER_PORT }} timeout=180
 
 - name: Trigger a Go configuration backup
-  uri: url=http://{{ ansible_hostname }}:8153/go/api/admin/start_backup
+  uri: url=http://{{ ansible_hostname }}:{{ GOCD_SERVER_PORT }}/go/api/admin/start_backup
      method=POST user={{ GOCD_DEFAULT_ADMIN }} password={{ GOCD_DEFAULT_PASS }}
 
 - name: Creating Go configuration file

--- a/templates/go-agent-defaults
+++ b/templates/go-agent-defaults
@@ -1,4 +1,5 @@
 # {{ ansible_managed }}
+{{GOCD_AGENT_ADDITIONAL_DEFAULTS}}
 
 export GO_SERVER={{ GOCD_SERVER_HOST }}
 export GO_SERVER_PORT={{ GOCD_SERVER_PORT }}

--- a/templates/go-server-defaults
+++ b/templates/go-server-defaults
@@ -1,4 +1,5 @@
 # {{ ansible_managed }}
+{{GOCD_SERVER_ADDITIONAL_DEFAULTS}}
 
 export GO_SERVER_PORT={{ GOCD_SERVER_PORT }}
 export GO_SERVER_SSL_PORT={{ GOCD_SERVER_SSL_PORT | default(8154) }}


### PR DESCRIPTION
Sometimes you need to insert additional environment variables, e.g. for proxy settings when GOCD is running in an intranet.