### PR TITLE
Do not set version=latest when package manager is pkg.

### DIFF
--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: apt install go-agent
   sudo: yes
-  apt: pkg=go-agent={{ GOCD_GO_VERSION }} state=present force=yes
+  apt: pkg=go-agent{{ '=' + GOCD_GO_VERSION if GOCD_GO_VERSION != 'latest' else ''}} state=present force=yes
   when: ansible_pkg_mgr=='apt'
   # notify:
   # - restart go-agent

--- a/roles/server/tasks/go-server.yml
+++ b/roles/server/tasks/go-server.yml
@@ -8,7 +8,7 @@
 
 - name: apt install go-server
   sudo: yes
-  apt: pkg=go-server={{ GOCD_GO_VERSION }} state=present force=yes
+  apt: pkg=go-server{{ '=' + GOCD_GO_VERSION if GOCD_GO_VERSION != 'latest' else ''}} state=present force=yes
   when: ansible_pkg_mgr=='apt'
 
 - name: flag that we're configuration a Go server


### PR DESCRIPTION
No value implies latest by default. It results in an error to specify version=latest.

`E: Version 'latest' for 'go-server' was not found`
