### PR TITLE
Using correct service manager to handle goagents.

### DIFF
--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -85,7 +85,7 @@
   when: gocd_tmp_new_agent.changed
 
 - name: Ensure Go-agents are not running yet (waiting for server config), but are enabled on startup.
-  service: "name=go-agent{{ item }} state=stopped enabled=yes"
+  service: "name=go-agent{{ item }} state=stopped enabled=yes use=service"
   become: yes
   notify: restart all agents
   with_sequence: "count={{ GOCD_AGENT_INSTANCES }}"


### PR DESCRIPTION
Forced the "service" service manager in service module through "use" argument.
The service module actually uses system specific modules, it uses the value of the 'ansible_service_mgr'. In RHEL 7.2 this means 'systemd' which ignore the /etc/init.d/go-agent? scripts. Forcing the "service" option must work on every OS.

This bug caused to task "Ensure Go-agents are not running yet (waiting for server config), but are enabled on startup." to always fail in RHEL 7.2.