### PR TITLE
Allow adding extra lines to /etc/defaults/go-agent conf

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -32,3 +32,6 @@ GOCD_SSH_KNOWN_DOMAIN: github.com
 
 # Used internally. Do not change.
 GOCD_VALID_EMAIL_REGEX: '\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b'
+
+# For providing extra lines into /etc/defaults/go-agent
+GOCD_AGENT_DEFAULT_EXTRAS: ""

--- a/roles/agent/templates/go-agent-defaults
+++ b/roles/agent/templates/go-agent-defaults
@@ -18,3 +18,6 @@ then
    ssh-add /var/go/.ssh/{{ GOCD_SSH_PRIVATE_KEY | basename}}
 fi
 {% endif %}
+{% if GOCD_AGENT_DEFAULT_EXTRAS %}
+{{ GOCD_AGENT_DEFAULT_EXTRAS }}
+{% endif %}


### PR DESCRIPTION
In my Go installation I need to provide some extra paths to search
through as I've installed custom software there. By adding this
variable I'm able to configure these custom paths like so:

    $ cat group_vars/gocd.yml
    GOCD_AGENT_DEFAULT_EXTRAS: |
     source {{ python2_enable_source_script }}
     source {{ python3_enable_source_script }}
     source {{ postgres_path_load_script }}